### PR TITLE
fix: allow application/pdf MIME type for Image modality in tool results

### DIFF
--- a/tool.go
+++ b/tool.go
@@ -587,7 +587,8 @@ func validateToolResultMessage(message *Message, toolCallID string) error {
 					return fmt.Errorf("block %d has text modality but non-text MIME type: %q", i, block.MimeType)
 				}
 			case Image:
-				if !strings.HasPrefix(block.MimeType, "image/") {
+				// Allow image/* MIME types and application/pdf (PDFs are treated as image modality)
+				if !strings.HasPrefix(block.MimeType, "image/") && block.MimeType != "application/pdf" {
 					return fmt.Errorf("block %d has image modality but non-image MIME type: %q", i, block.MimeType)
 				}
 			case Audio:

--- a/tool_validation_test.go
+++ b/tool_validation_test.go
@@ -82,6 +82,23 @@ func TestValidateToolResultMessage(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name: "valid PDF message",
+			message: Message{
+				Role: ToolResult,
+				Blocks: []Block{
+					{
+						ID:           "pdf-id",
+						BlockType:    Content,
+						ModalityType: Image,
+						MimeType:     "application/pdf",
+						Content:      Str("base64-pdf-data"),
+					},
+				},
+			},
+			toolCallID: "pdf-id",
+			wantErr:    false,
+		},
+		{
 			name: "valid multi-block message",
 			message: Message{
 				Role: ToolResult,


### PR DESCRIPTION
## Summary
Fixes #3

The `validateToolResultMessage` function was rejecting PDF content in tool results because it validated that Image modality blocks must have `image/*` MIME types.

However, `PDFBlock()` creates blocks with:
- `ModalityType: Image`
- `MimeType: "application/pdf"`

This is by design since PDFs are treated as a special type of image modality by model providers (converted to images at the API level).

## Changes
- Updated MIME type validation in `validateToolResultMessage` to also accept `application/pdf` for Image modality
- Added test case for valid PDF message in tool results

## Testing
All unit tests pass, including the new test case for PDF validation.